### PR TITLE
Branch 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ EpicEditor is an embeddable JavaScript [Markdown](http://daringfireball.net/proj
 WYSIWYGs suck and they suck hard. Markdown is quickly becoming the replacement. [GitHub](http://github.com), [Stackoverflow](http://stackoverflow.com), and even blogging apps like [Posterous](http://posterous.com) support Markdown now. This allows you to generate a Markdown editor with a preview, fullscreen editing, full CSS theming, and offline support with a simple:
 
 ```javascript
-var editor = new EpicEditor(element).load();
+var editor = new EpicEditor().load();
 ```
 
 ###How
@@ -20,7 +20,7 @@ var editor = new EpicEditor(element).load();
 EpicEditor allows for all kinds of customization. For simple drop-in-and-go support see the quick start right below, otherwise checkout the full API.
 
 ####Quick Start
-EpicEditor is easy to implement simply clone the repo and then it only needs an element to add the editor to and then you call `load()` when you're ready.
+EpicEditor is easy to implement. Simply clone the repo, provide a container and call `load()` when you're ready.
 
 #####Step 1: Clone the repo
 
@@ -28,17 +28,17 @@ EpicEditor is easy to implement simply clone the repo and then it only needs an 
 $ git clone git@github.com:OscarGodson/EpicEditor
 ```
 
-#####Step 2: Load the script
+#####Step 2: Position the container and load the script
 
 ```html
+<div id="epiceditor"></div>
 <script src="epiceditor.js"></script>
 ```
 
 #####Step 3: Init EpicEditor
 
 ```javascript
-var element = document.getElementById('editor-wrapper');
-var editor = new EpicEditor(element).load();
+var editor = new EpicEditor().load();
 ```
 
 ####API
@@ -49,10 +49,9 @@ The constructor is first (`EpicEditor()`), but everything after are methods of t
 **Table of Contents:**
 
 <ol>
-  <li><a href="#api-epiceditor"><code>EpicEditor()</code></a></li>
+  <li><a href="#api-epiceditor"><code>EpicEditor</code></a>(<a href="#api-options"><code>[<em>options</em>]</code></a>)</li>
   <li><a href="#api-load"><code>load()</code></a></li>
   <li><a href="#api-unload"><code>unload()</code></a></li>
-  <li><a href="#api-options"><code>options()</code></a></li>
   <li><a href="#api-get"><code>get()</code></a></li>
   <li><a href="#api-open"><code>open()</code></a></li>
   <li><a href="#api-import"><code>import()</code></a></li>
@@ -69,17 +68,75 @@ The constructor is first (`EpicEditor()`), but everything after are methods of t
 
 #####Constructor
 
-<h6 id="api-epiceditor">EpicEditor(<em>element</em>)</h6>
+<h6 id="api-epiceditor">EpicEditor([<em>options</em>])</h6>
 
-Creates a new EpicEditor instance. Give it an element you want to insert the editor into
+Creates a new EpicEditor instance. Customize the instance by passing the <code>options</code> parameter.</p>
 
 **Example:**
 
 ```javascript
-var editor = new EpicEditor(element);
+var opts = { /* options */ },
+    editor = new EpicEditor(opts);
 ```
 
-_Note:_ all the examples below will continue to use this same constructor.
+<h6 id="api-options">Options</h6>
+
+Customize the editor instance. The example below has all the options available currently with their respective defaults.
+
+<ul>
+  <li><code>container</code>: The ID of the target container element. By default it will look for an element with ID <code>epiceditor</code>.</li>
+  <li><code>basePath</code>: The base path of the directory containing the <code>/themes</code>, <code>/images</code>, etc. It's <code>epiceditor</code> by default. <em>Don't add a trailing slash!</em></li>
+  <li><code>localStorageName</code>: The name to use for the localStorage object, set to <code>epiceditor</code> by default.</li>
+  <li><code>file</code>
+    <ul>
+      <li><code>name</code>: If no file exists with this name a new one will be made, otherwise the existing will be opened.</li>
+      <li><code>defaultContent</code>: The content to show if no content exists for that file.</li>
+    </ul>
+  </li>
+  <li><code>themes</code>
+    <ul>
+      <li><code>editor</code>: The theme for the editor which is a textarea inside of an iframe.</li>
+      <li><code>preview</code>: The theme for the previewer which is a div of content inside of an iframe.</li>
+    </ul>
+  </li>
+  <li><code>focusOnLoad</code>: Will focus on the editor on load. It's <code>false</code> by default.</li>
+  <li><code>shortcuts</code>
+    <ul>
+      <li><code>modifier</code>: The modifying key for shortcuts. It's <code>18</code> (the <kbd>alt</kbd> key) by default, to reduce default browser shortcut conflicts.</li>
+      <li><code>fullscreen</code>: The fullscreen shortcut key. It's <code>70</code> (<kbd>f</kbd> key) by default.</li>
+      <li><code>preview</code>: The preview shortcut key. It's <code>80</code> (<kbd>p</kbd> key) by default.</li>
+      <li><code>edit</code>: The edit mode shortcut key. It's <code>79</code> (<kbd>o</kbd> key) by default.</li>
+    </ul>
+  </li>
+</ul>
+
+Example with defaults:
+
+```javascript
+var opts = {
+  container: 'epiceditor',
+  basePath: 'epiceditor',
+  localStorageName: 'epiceditor',
+  file: {
+    name: 'epiceditor',
+    defaultContent: ''
+  },
+  themes: {
+    preview:'/themes/preview/preview-dark.css',
+    editor:'/themes/editor/epic-dark.css'
+  },
+  focusOnLoad: false,
+  shortcuts: {
+    modifier: 18
+    fullscreen: 70
+    preview: 80
+    edit: 79
+  }
+}
+var editor = new EpicEditor(opts);
+```
+
+_Note: all the examples below will continue to use this same constructor._
 
 #####Methods
 
@@ -94,6 +151,7 @@ editor.load();
 ```
 
 <h6 id="api-unload">unload([<em>callback</em>])</h6>
+
 Unloads the editor by removing the `<iframe>`, but will keep any options you set and file contents so you can easily call `.load()` again. Will trigger the `unload` event, or you can use the callback instead.
 
 **Example:**
@@ -102,50 +160,8 @@ Unloads the editor by removing the `<iframe>`, but will keep any options you set
 editor.unload();
 ```
 
-<h6 id="api-options">options(<em>options</em>)</h6>
-Lets you set options for the editor. The example below has all the options available currently.
-
-
-- `basePath`: The base path of the directory containing the `/themes`, `/images`, etc. It's `epiceditor` by default. _Don't add a trailing slash!_.
-
-- `file.name`: If no file exists with this name a new one will be made, otherwise the existing will be opened.
-
-- `file.defaultContent`: The content to show if no content exists for that file.
-
-- `themes.editor`: The theme for the editor which is a textarea inside of an iframe.
-
-- `themes.preview`: The theme for the previewer which is a div of content inside of an iframe.
-
-- `focusOnLoad`: Will focus on the editor on load. It's `false` by default.
-
-- `shortcuts.modifier`: The modifying key for shortcuts. It's `18` (the alt key) by default, to reduce default browser shortcut conflicts.
-
-- `shortcuts.fullscreen`: The fullscreen shortcut key. It's `70` (f keycode) by default.
-
-- `shortcuts.preview`: The preview shortcut key. It's `80` (p keycode) by default.
-
-- `shortcuts.edit`: The edit mode shortcut key. It's `79` (o keycode) by default.
-
-**Example:**
-
-```javascript
-editor.options({
-  file:{
-    name:'example',
-    defaultContent:'Write text in here!'
-  },
-  themes:{
-    editor:'/css/epiceditor/editor-custom.css',
-    preview:'/css/epiceditor/preview-custom.css'
-  },
-  focusOnLoad:true,
-  shortcuts: {
-    preview: 77 //M
-  }
-}).load();
-```
-
 <h6 id="api-get">get(<em>element</em>)</h6>
+
 Will grab an element of the editor for easy DOM manipulation inside of the editor.
 
 - `'document'`: Returns the iframe element.
@@ -158,33 +174,36 @@ Will grab an element of the editor for easy DOM manipulation inside of the edito
 
 ```javascript
 someBtn.onclick = function(){
-  console.log(ee.get('editor').value); //Would return the editor's content
+  console.log(editor.get('editor').value); //Would return the editor's content
 }
 ```
 
 <h6 id="api-open">open(<em>filename</em>)</h6>
+
 Opens a file into the editor.
 
 **Example:**
 
 ```javascript
 openFileBtn.onclick = function(){
-  ee.open('some-file'); //Open a file when the user clicks this button
+  editor.open('some-file'); //Open a file when the user clicks this button
 }
 ```
 
 <h6 id="api-import">import(<em>filename</em>,[<em>content</em>])</h6>
+
 Imports a string of markdown into a file. If the file already exists, it will be overwritten. Useful if you want to inject a bunch of content via AJAX.
 
 **Example:**
 
 ```javascript
 importFileBtn.onclick = function(){
-  ee.import('some-file',"#Imported markdown\nFancy, huh?"); //Imports a file when the user clicks this button
+  editor.import('some-file',"#Imported markdown\nFancy, huh?"); //Imports a file when the user clicks this button
 }
 ```
 
 <h6 id="api-rename">rename(<em>oldName</em>,<em>newName</em>)</h6>
+
 Renames a file.
 
 **Example:**
@@ -192,50 +211,54 @@ Renames a file.
 ```javascript
 renameFileBtn.onclick = function(){
   var newName = prompt('What do you want to rename this file to?');
-  ee.rename('old-filename',newName); //Prompts a user and renames a file on button click
+  editor.rename('old-filename',newName); //Prompts a user and renames a file on button click
 }
 ```
 
 <h6 id="api-save">save()</h6>
+
 Manually save a file. EpicEditor will save on keyup by default but if you are inserting content via ajax for example, this is useful.
 
 **Example:**
 
 ```javascript
 saveFileBtn.onclick = function(){
-  ee.save();
+  editor.save();
 }
 ```
 
 <h6 id="api-remove">remove(<em>name</em>)</h6>
+
 Deletes a file.
 
 **Example:**
 
 ```javascript
 removeFileBtn.onclick = function(){
-  ee.remove('some-file');
+  editor.remove('some-file');
 }
 ```
 
 <h6 id="api-on">on(<em>event</em>,<em>handler</em>)</h6>
+
 Sets up an event handler (callback) for a specified event. For all event types, see the <a href="#events">Events</a> section below.
 
 **Example:**
 
 ```javascript
-ee.on('unload',function(){
+editor.on('unload',function(){
   console.log('Editor was removed');
 });
 ```
 
 <h6 id="api-emit">emit(<em>event</em>)</h6>
+
 Sets off an event manually. Like jQuery's `.trigger()`
 
 **Example:**
 
 ```javascript
-ee.emit('unload'); //Would trigger the above handler
+editor.emit('unload'); //Would trigger the above handler
 ```
 
 <h6 id="api-removeListener">removeListener(<em>event</em>,[<em>handler</em>])</h6>
@@ -245,39 +268,42 @@ Allows you to remove all listeners for an event, or just the specified one.
 **Example:**
 
 ```javascript
-ee.removeListener('unload'); //The handler above would no longer fire
+editor.removeListener('unload'); //The handler above would no longer fire
 ```
 
 <h6 id="api-preview">preview()</h6>
+
 Will put the editor into preview mode.
 
 **Example:**
 
 ```javascript
 previewBtn.onclick = function(){
-  ee.preview();
+  editor.preview();
 }
 ```
 
 <h6 id="api-edit">edit()</h6>
+
 Will put the editor into edit mode.
 
 **Example:**
 
 ```javascript
 editBtn.onclick = function(){
-  ee.edit();
+  editor.edit();
 }
 ```
 
 <h6 id="api-exportHTML">exportHTML()</h6>
+
 Will return the generated HTML from the Markdown that you see in the preview mode. Useful to saving content to a database.
 
 **Example:**
 
 ```javascript
 syncWithServerBtn.onclick = function(){
-  var theHTML = ee.exportHTML();
+  var theHTML = editor.exportHTML();
   saveToServerAjaxCall('/save',{data:theHTML},function(){
     console.log('data was saved to a db');
   });
@@ -287,21 +313,27 @@ syncWithServerBtn.onclick = function(){
 <h5 id="events">Events</h5>
 
 <h6 id="">load</h6>
+
 Fires when the editor is loaded via `.load()`.
 
 <h6 id="">unload</h6>
+
 Fires when the editor is unloaded via `.unload()`.
 
 <h6 id="">preview</h6>
+
 Fires when the user clicks the preview button, or when `.preview()` is called.
 
 <h6 id="">edit</h6>
+
 Fires when the user clicks the edit button, or when `.edit()` is called.
 
 <h6 id="">save</h6>
+
 Fires when the file is saved automatically by EpicEditor, or when `.save()` is called.
 
 <h6 id="">open</h6>
+
 Fires when the file is opened on load automatically by EpicEditor, or when `.open()` is called.
 
 ####Theming

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Customize the editor instance. The example below has all the options available c
       <li><code>defaultContent</code>: The content to show if no content exists for that file.</li>
     </ul>
   </li>
-  <li><code>themes</code>
+  <li><code>theme</code>
     <ul>
       <li><code>editor</code>: The theme for the editor which is a textarea inside of an iframe.</li>
       <li><code>preview</code>: The theme for the previewer which is a div of content inside of an iframe.</li>
     </ul>
   </li>
   <li><code>focusOnLoad</code>: Will focus on the editor on load. It's <code>false</code> by default.</li>
-  <li><code>shortcuts</code>
+  <li><code>shortcut</code>
     <ul>
       <li><code>modifier</code>: The modifying key for shortcuts. It's <code>18</code> (the <kbd>alt</kbd> key) by default, to reduce default browser shortcut conflicts.</li>
       <li><code>fullscreen</code>: The fullscreen shortcut key. It's <code>70</code> (<kbd>f</kbd> key) by default.</li>
@@ -121,12 +121,12 @@ var opts = {
     name: 'epiceditor',
     defaultContent: ''
   },
-  themes: {
+  theme: {
     preview:'/themes/preview/preview-dark.css',
     editor:'/themes/editor/epic-dark.css'
   },
   focusOnLoad: false,
-  shortcuts: {
+  shortcut: {
     modifier: 18
     fullscreen: 70
     preview: 80

--- a/epiceditor.js
+++ b/epiceditor.js
@@ -539,6 +539,8 @@
     var self = this;
     var editor = window.parent.document.getElementById(self.settings.id);
     editor.parentNode.removeChild(editor);
+    callback = callback || function(){};
+    
     callback.call(this);
     self.emit('unload');
     return self;

--- a/epiceditor.js
+++ b/epiceditor.js
@@ -218,22 +218,14 @@
    * @returns {object} EpicEditor will be returned
    */
   function EpicEditor(options){
-    var uId = 'epiceditor-'+Math.round(Math.random()*100000)
-      , fileName = options.element ? options.element.id : 'epiceditor';
-
-    //TODO: Check for data-filename as well
-    if(!fileName){ //If there is no id on the element to use, just use "default"
-      fileName = 'default';
-    }
-
     //Default settings will be overwritten/extended by options arg
-    var defaults = {
-          id: uId //Because there might be multiple editors, we create a random id
-        , container: 'epiceditor'
+    var opts = options || {}
+      , defaults = {
+          container: 'epiceditor'
         , basePath: 'epiceditor'
         , localStorageName: 'epiceditor'
         , file: {
-            name: fileName //Use the DOM element's ID for an unique persistent file name
+            name: opts.container || 'epiceditor' //Use the container's ID for an unique persistent file name - will be overwritten if passed a file.name opt
           , defaultContent: ''
           }
         , theme: {
@@ -249,8 +241,12 @@
           }
         };
 
-    this.settings = _mergeObjs(true, defaults, options);
-
+    this.settings = _mergeObjs(true, defaults, opts);
+    
+    // Protect the id and overwrite if passed in as an option
+    // TODO: Consider moving this off of the settings object to something like this.instanceId or this.iframeId
+    this.settings.id = 'epiceditor-'+Math.round(Math.random()*100000);
+    
     //Setup local storage of files
     if(localStorage){
       if(!localStorage[this.settings.localStorageName]){

--- a/epiceditor.js
+++ b/epiceditor.js
@@ -236,12 +236,12 @@
             name: fileName //Use the DOM element's ID for an unique persistent file name
           , defaultContent: ''
           }
-        , themes: {
+        , theme: {
             preview:'/themes/preview/preview-dark.css'
           , editor:'/themes/editor/epic-dark.css'
           }
         , focusOnLoad:false
-        , shortcuts: { 
+        , shortcut: { 
             modifier: 18 // alt keycode
           , fullscreen: 70 // f keycode
           , preview: 80 // p keycode
@@ -321,7 +321,7 @@
     var iframeBody = self.iframe.body;
     iframeBody.style.padding = '0';
     iframeBody.style.margin = '0';
-    _insertCSSLink(self.settings.basePath+self.settings.themes.editor,self.iframe);
+    _insertCSSLink(self.settings.basePath+self.settings.theme.editor,self.iframe);
     
     //Add a relative style to the overall wrapper to keep CSS relative to the editor
     self.iframe.getElementsByClassName('epiceditor-wrapper')[0].style.position = 'relative';
@@ -353,7 +353,7 @@
     }
 
     //Preload the preview theme:
-    _insertCSSLink(self.settings.basePath+self.settings.themes.preview, self.iframe, 'theme');
+    _insertCSSLink(self.settings.basePath+self.settings.theme.preview, self.iframe, 'theme');
 
     //If there is a file to be opened with that filename and it has content...
     this.open(self.settings.file.name);
@@ -501,25 +501,25 @@
     //Add keyboard shortcuts for convenience.
     var isMod = false;
     self.iframe.addEventListener('keyup', function(e){
-      if(e.keyCode === self.settings.shortcuts.modifier){ isMod = false };
+      if(e.keyCode === self.settings.shortcut.modifier){ isMod = false };
     });
     self.iframe.addEventListener('keydown', function(e){
-      if(e.keyCode === self.settings.shortcuts.modifier){ isMod = true }; //check for modifier press(default is alt key), save to var
+      if(e.keyCode === self.settings.shortcut.modifier){ isMod = true }; //check for modifier press(default is alt key), save to var
 
       //Check for alt+p and make sure were not in fullscreen - default shortcut to switch to preview
-      if(isMod === true && e.keyCode === self.settings.shortcuts.preview && !fullScreenApi.isFullScreen()){
+      if(isMod === true && e.keyCode === self.settings.shortcut.preview && !fullScreenApi.isFullScreen()){
         e.preventDefault();
         self.preview();
       }
       //Check for alt+o - default shortcut to switch back to the editor
-      if(isMod === true && e.keyCode === self.settings.shortcuts.edit){
+      if(isMod === true && e.keyCode === self.settings.shortcut.edit){
         e.preventDefault();
         if(!fullScreenApi.isFullScreen()){
           self.edit();
         }
       }
       //Check for alt+f - default shortcut to make editor fullscreen
-      if(isMod === true && e.keyCode === self.settings.shortcuts.fullscreen){
+      if(isMod === true && e.keyCode === self.settings.shortcut.fullscreen){
         e.preventDefault();
         //TODO remove this once issue #32 is fixed, but don't until #32 or else FF will error out
         if(document.body.webkitRequestFullScreen){
@@ -555,7 +555,7 @@
    */
   EpicEditor.prototype.preview = function(theme,live){
     var self = this
-    ,   themePath = self.settings.basePath+self.settings.themes.preview;
+    ,   themePath = self.settings.basePath+self.settings.theme.preview;
     if(typeof theme === 'boolean'){
       live = theme;
       theme = themePath

--- a/epiceditor.js
+++ b/epiceditor.js
@@ -214,51 +214,54 @@
   /**
    * Initiates the EpicEditor object and sets up offline storage as well
    * @class Represents an EpicEditor instance
-   * @param {object} e A DOM object for the editor to be placed in
+   * @param {object} options An optional customization object
    * @returns {object} EpicEditor will be returned
    */
-  function EpicEditor(e){
+  function EpicEditor(options){
     var uId = 'epiceditor-'+Math.round(Math.random()*100000)
-    ,   fileName = e.id;
+      , fileName = options.element ? options.element.id : 'epiceditor';
 
     //TODO: Check for data-filename as well
     if(!fileName){ //If there is no id on the element to use, just use "default"
       fileName = 'default';
     }
 
-    //Default settings (will be overwritten if .options() is called with parameters)
-    this.settings = {
-      basePath:'epiceditor'
-    , themes: {
-        preview:'/themes/preview/preview-dark.css'
-      , editor:'/themes/editor/epic-dark.css'
-      }
-    , file: {
-        name:fileName //Use the DOM element's ID for an unique persistent file name
-      , defaultContent:''
-      }
-      //Because there might be multiple editors, we create a random id
-    , id:uId
-    , focusOnLoad:false
-    , shortcuts: { 
-        modifier: 18 // alt keycode
-      , fullscreen: 70 // f keycode
-      , preview: 80 // p keycode
-      , edit: 79 // o keycode
-      }
-    };
+    //Default settings will be overwritten/extended by options arg
+    var defaults = {
+          id: uId //Because there might be multiple editors, we create a random id
+        , container: 'epiceditor'
+        , basePath: 'epiceditor'
+        , localStorageName: 'epiceditor'
+        , file: {
+            name: fileName //Use the DOM element's ID for an unique persistent file name
+          , defaultContent: ''
+          }
+        , themes: {
+            preview:'/themes/preview/preview-dark.css'
+          , editor:'/themes/editor/epic-dark.css'
+          }
+        , focusOnLoad:false
+        , shortcuts: { 
+            modifier: 18 // alt keycode
+          , fullscreen: 70 // f keycode
+          , preview: 80 // p keycode
+          , edit: 79 // o keycode
+          }
+        };
+
+    this.settings = _mergeObjs(true, defaults, options);
 
     //Setup local storage of files
     if(localStorage){
-      if(!localStorage['epiceditor']){
+      if(!localStorage[this.settings.localStorageName]){
         //TODO: Needs a dynamic file name!
         var defaultStorage = {files:{}};
         defaultStorage.files[this.settings.file.name] = this.settings.file.defaultContent;
         defaultStorage = JSON.stringify(defaultStorage);
-        localStorage['epiceditor'] = defaultStorage;
+        localStorage[this.settings.localStorageName] = defaultStorage;
       }
-      else if(!JSON.parse(localStorage['epiceditor']).files[this.settings.file.name]){
-        JSON.parse(localStorage['epiceditor']).files[this.settings.file.name] = this.settings.file.defaultContent;
+      else if(!JSON.parse(localStorage[this.settings.localStorageName]).files[this.settings.file.name]){
+        JSON.parse(localStorage[this.settings.localStorageName]).files[this.settings.file.name] = this.settings.file.defaultContent;
       }
       else{
         this.content = this.settings.file.defaultContent;
@@ -268,19 +271,8 @@
     if(!this.events){
       this.events = {}; 
     }
-    this.element = e;
+    this.element = document.getElementById(this.settings.container);
     return this;
-  }
-
-  /**
-   * Changes default options such as theme, id, etc for the EpicEditor instance
-   * @param  {object} options A key/value pair of options you want to change from the default
-   * @returns {object} EpicEditor will be returned
-   */
-  EpicEditor.prototype.options = function(options){
-    var self = this;
-    self.settings = _mergeObjs(true, this.settings, options);
-    return self;
   }
 
   /**
@@ -308,6 +300,9 @@
     //Write an iframe and then select it for the editor
     this.element.innerHTML = '<iframe scrolling="no" frameborder="0" id= "'+self.settings.id+'"></iframe>';
     var iframeElement = document.getElementById(self.settings.id);
+
+    // Store a reference to the iframeElement itself
+    self.iframeElement = iframeElement;
 
     //Grab the innards of the iframe (returns the document.body)
     self.iframe = iframeElement.contentDocument || iframeElement.contentWindow.document;
@@ -634,8 +629,8 @@
   EpicEditor.prototype.open = function(name){
     var self = this;
     name = name || self.settings.file.name;
-    if(localStorage && localStorage['epiceditor']){
-      var fileObj = JSON.parse(localStorage['epiceditor']).files;
+    if(localStorage && localStorage[self.settings.localStorageName]){
+      var fileObj = JSON.parse(localStorage[self.settings.localStorageName]).files;
       if(fileObj[name]){
         self.editor.value = fileObj[name];
       }
@@ -659,9 +654,9 @@
     var self = this;
     file = file || self.settings.file.name;
     content = content || this.editor.value;
-    var s = JSON.parse(localStorage['epiceditor']);
+    var s = JSON.parse(localStorage[self.settings.localStorageName]);
     s.files[file] = content;
-    localStorage['epiceditor'] = JSON.stringify(s);
+    localStorage[self.settings.localStorageName] = JSON.stringify(s);
     this.emit('save');
     return this;
   }
@@ -674,9 +669,9 @@
   EpicEditor.prototype.remove = function(name){
     var self = this;
     name = name || self.settings.file.name;
-    var s = JSON.parse(localStorage['epiceditor']);
+    var s = JSON.parse(localStorage[self.settings.localStorageName]);
     delete s.files[name];
-    localStorage['epiceditor'] = JSON.stringify(s);
+    localStorage[self.settings.localStorageName] = JSON.stringify(s);
     this.emit('remove');
     return this;
   };
@@ -706,10 +701,10 @@
    */
   EpicEditor.prototype.rename = function(oldName,newName){
     var self = this;
-    var s = JSON.parse(localStorage['epiceditor']);
+    var s = JSON.parse(localStorage[self.settings.localStorageName]);
     s.files[newName] = s.files[oldName];
     delete s.files[oldName];
-    localStorage['epiceditor'] = JSON.stringify(s);
+    localStorage[self.settings.localStorageName] = JSON.stringify(s);
     self.open(newName);
     return this;
   };

--- a/index.html
+++ b/index.html
@@ -94,14 +94,14 @@
             <li><code>defaultContent</code>: The content to show if no content exists for that file.</li>
           </ul>
         </li>
-        <li><code>themes</code>
+        <li><code>theme</code>
           <ul>
             <li><code>editor</code>: The theme for the editor which is a textarea inside of an iframe.</li>
             <li><code>preview</code>: The theme for the previewer which is a div of content inside of an iframe.</li>
           </ul>
         </li>
         <li><code>focusOnLoad</code>: Will focus on the editor on load. It's <code>false</code> by default.</li>
-        <li><code>shortcuts</code>
+        <li><code>shortcut</code>
           <ul>
             <li><code>modifier</code>: The modifying key for shortcuts. It's <code>18</code> (the <kbd>alt</kbd> key) by default, to reduce default browser shortcut conflicts.</li>
             <li><code>fullscreen</code>: The fullscreen shortcut key. It's <code>70</code> (<kbd>f</kbd> key) by default.</li>
@@ -119,12 +119,12 @@
     name: 'epiceditor',
     defaultContent: ''
   },
-  themes: {
+  theme: {
     preview:'/themes/preview/preview-dark.css',
     editor:'/themes/editor/epic-dark.css'
   },
   focusOnLoad: false,
-  shortcuts: {
+  shortcut: {
     modifier: 18
     fullscreen: 70
     preview: 80

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <style>
       body {background:#FEED79;}
       #wrapper { width:600px;margin:0 auto;font-family:helvetica,arial,sans-serif;line-height:1.4em; }
-      #example-1 { height:349px;border:1px solid #000; }
+      #epiceditor { height:349px;border:1px solid #000; }
       h1 { border-bottom:2px solid #000; padding:0 0 15px 0; font-size:38px; position:relative; }
       h3,h4,h5,h6 { margin-bottom:0; }
       h3 { font-size:20px; }
@@ -18,6 +18,7 @@
       p { font-size:13px; margin:5px 0; }
       a { background:#000;color:#fff;text-decoration:none; }
       .example { font-weight:bold; font-size:12px; }
+
     </style>
     <link rel="stylesheet" href="http://yandex.st/highlightjs/6.1/styles//sunburst.min.css">
   </head>
@@ -27,28 +28,26 @@
       <h2>An Embeddable JavaScript Markdown Editor</h2>
       <p>EpicEditor is an embeddable JavaScript <a href="http://daringfireball.net/projects/markdown/">Markdown</a> editor with some minor Markdown enhancements such as automatic link creation and code fencing.</p>
 
-      <div id="example-1"></div>
+      <div id="epiceditor"></div>
 
       <h3>Why</h3>
       <p>WYSIWYGs suck and they suck hard. Markdown is quickly becoming the replacement. <a href="http://github.com">GitHub</a>, <a href="http://stackoverflow.com">Stackoverflow</a>, and even blogging apps like <a href="http://posterous.com">Posterous</a> support Markdown now. This allows you to generate a Markdown editor with a preview, fullscreen editing, full CSS theming, and offline support with a simple:</p>
-      <pre><code class="javascript">var editor = new EpicEditor(element).load();</code></pre>
-
+      <pre><code class="javascript">var editor = new EpicEditor().load();</code></pre>
       <h3>How</h3>
       <p>EpicEditor allows for all kinds of customization. For simple drop-in-and-go support see the <a href="#quick-start">quick start</a> right below, otherwise checkout the full <a href="#api">API</a>.</p>
       
       <h4 id="quick-start">Quick Start</h4>
-      <p>EpicEditor is easy to implement simply clone the repo and then it only needs an element to add the editor to and then you call <code>load()</code> when you're ready.</p>
+      <p>EpicEditor is easy to implement. Simply clone the repo, provide a container and call <code>load()</code> when you're ready.</p>
       
       <h5>Step 1: Clone the repo</h5>
       <pre><code class="bash">$ git clone git@github.com:OscarGodson/EpicEditor</code></pre>
 
-      <h5>Step 2: Load the script</h5>
-      <pre><code ="html">&lt;script src="epiceditor.js"&gt;&lt;/script&gt;</code></pre>
-
+      <h5>Step 2: Position the container and load the script</h5>
+      <pre><code ="html">&lt;div id="epiceditor"&gt;&lt;/div&gt;
+&lt;script src="epiceditor.js"&gt;&lt;/script&gt;</code></pre>
 
       <h5>Step 3: Init EpicEditor</h5>
-      <pre><code class="javascript">var element = document.getElementById('editor-wrapper');
-var editor = new EpicEditor(element).load();</code></pre>
+      <pre><code class="javascript">var editor = new EpicEditor().load();</code></pre>
 
       <h4 id="api">API</h4>
       
@@ -58,10 +57,9 @@ var editor = new EpicEditor(element).load();</code></pre>
       <p><strong>Table of Contents:</strong></p>
 
       <ol>
-        <li><a href="#api-epiceditor"><code>EpicEditor()</code></a></li>
+        <li><a href="#api-epiceditor"><code>EpicEditor</code></a>(<a href="#api-options"><code>[<em>options</em>]</code></a>)</li>
         <li><a href="#api-load"><code>load()</code></a></li>
         <li><a href="#api-unload"><code>unload()</code></a></li>
-        <li><a href="#api-options"><code>options()</code></a></li>
         <li><a href="#api-get"><code>get()</code></a></li>
         <li><a href="#api-open"><code>open()</code></a></li>
         <li><a href="#api-import"><code>import()</code></a></li>
@@ -78,10 +76,63 @@ var editor = new EpicEditor(element).load();</code></pre>
 
       <h5>Constructor</h5>
       
-      <h6 id="api-epiceditor">EpicEditor(<em>element</em>)</h6>
-      <p>Creates a new EpicEditor instance. Give it an element you want to insert the editor into.</p>
+      <h6 id="api-epiceditor">EpicEditor([<em>options</em>])</h6>
+      <p>Creates a new EpicEditor instance. Customize the instance by passing the <code>options</code> parameter.</p>
       <p class="example">Example:</p>
-      <pre><code class="javascript">var editor = new EpicEditor(element);</code></pre>
+      <pre><code class="javascript">var opts = { /* options */ },
+    editor = new EpicEditor(opts);</code></pre>
+      
+      <h6 id="api-options">Options</h6>
+      <p>Customize the editor instance. The example below has all the options available currently with their respective defaults.</p>
+      <ul>
+        <li><code>container</code>: The ID of the target container element. By default it will look for an element with ID <code>epiceditor</code>.</li>
+        <li><code>basePath</code>: The base path of the directory containing the <code>/themes</code>, <code>/images</code>, etc. It's <code>epiceditor</code> by default. <em>Don't add a trailing slash!</em></li>
+        <li><code>localStorageName</code>: The name to use for the localStorage object, set to <code>epiceditor</code> by default.</li>
+        <li><code>file</code>
+          <ul>
+            <li><code>name</code>: If no file exists with this name a new one will be made, otherwise the existing will be opened.</li>
+            <li><code>defaultContent</code>: The content to show if no content exists for that file.</li>
+          </ul>
+        </li>
+        <li><code>themes</code>
+          <ul>
+            <li><code>editor</code>: The theme for the editor which is a textarea inside of an iframe.</li>
+            <li><code>preview</code>: The theme for the previewer which is a div of content inside of an iframe.</li>
+          </ul>
+        </li>
+        <li><code>focusOnLoad</code>: Will focus on the editor on load. It's <code>false</code> by default.</li>
+        <li><code>shortcuts</code>
+          <ul>
+            <li><code>modifier</code>: The modifying key for shortcuts. It's <code>18</code> (the <kbd>alt</kbd> key) by default, to reduce default browser shortcut conflicts.</li>
+            <li><code>fullscreen</code>: The fullscreen shortcut key. It's <code>70</code> (<kbd>f</kbd> key) by default.</li>
+            <li><code>preview</code>: The preview shortcut key. It's <code>80</code> (<kbd>p</kbd> key) by default.</li>
+            <li><code>edit</code>: The edit mode shortcut key. It's <code>79</code> (<kbd>o</kbd> key) by default.</li>
+          </ul>
+        </li>
+      </ul>
+      <p class="example">Example with defaults:</p>
+      <pre><code class="javascript">var opts = {
+  container: 'epiceditor',
+  basePath: 'epiceditor',
+  localStorageName: 'epiceditor',
+  file: {
+    name: 'epiceditor',
+    defaultContent: ''
+  },
+  themes: {
+    preview:'/themes/preview/preview-dark.css',
+    editor:'/themes/editor/epic-dark.css'
+  },
+  focusOnLoad: false,
+  shortcuts: {
+    modifier: 18
+    fullscreen: 70
+    preview: 80
+    edit: 79
+  }
+}
+var editor = new EpicEditor(opts);</code></pre>
+      
       <p>Note: all the examples below will continue to use this same constructor.</p>
       
       <h5>Methods</h5>
@@ -96,36 +147,6 @@ var editor = new EpicEditor(element).load();</code></pre>
       <p class="example">Example:</p>
       <pre><code class="javascript">editor.unload();</code></pre>
       
-      <h6 id="api-options">options(<em>options</em>)</h6>
-      <p>Lets you set options for the editor. The example below has all the options available currently.</p>
-      <ul>
-        <li><code>basePath</code>: The base path of the directory containing the <code>/themes</code>, <code>/images</code>, etc. It's <code>epiceditor</code> by default. <em>Don't add a trailing slash!</em></li>
-        <li><code>file.name</code>: If no file exists with this name a new one will be made, otherwise the existing will be opened.</li>
-        <li><code>file.defaultContent</code>: The content to show if no content exists for that file.</li>
-        <li><code>themes.editor</code>: The theme for the editor which is a textarea inside of an iframe.</li>
-        <li><code>themes.preview</code>: The theme for the previewer which is a div of content inside of an iframe.</li>
-        <li><code>focusOnLoad</code>: Will focus on the editor on load. It's <code>false</code> by default.</li>
-        <li><code>shortcuts.modifier</code>: The modifying key for shortcuts. It's <code>18</code> (the <kbd>alt</kbd> key) by default, to reduce default browser shortcut conflicts.</li>
-        <li><code>shortcuts.fullscreen</code>: The fullscreen shortcut key. It's <code>70</code> (<kbd>f</kbd> key) by default.</li>
-        <li><code>shortcuts.preview</code>: The preview shortcut key. It's <code>80</code> (<kbd>p</kbd> key) by default.</li>
-        <li><code>shortcuts.edit</code>: The edit mode shortcut key. It's <code>79</code> (<kbd>o</kbd> key) by default.</li>
-      </ul>
-      <p class="example">Example:</p>
-      <pre><code class="javascript">editor.options({
-  file:{
-    name:'example',
-    defaultContent:'Write text in here!'
-  },
-  themes:{
-    editor:'/css/epiceditor/editor-custom.css',
-    preview:'/css/epiceditor/preview-custom.css'
-  },
-  focusOnLoad:true,
-  shortcuts: {
-    preview: 77 //M
-  }
-}).load();</code></pre>
-      
       <h6 id="api-get">get(<em>element</em>)</h6>
       <p>Will grab an element of the editor for easy DOM manipulation inside of the editor.</p>
       <ul>
@@ -137,21 +158,21 @@ var editor = new EpicEditor(element).load();</code></pre>
       </ul>
        <p class="example">Example:</p>
       <pre><code class="javascript">someBtn.onclick = function(){
-  console.log(ee.get('editor').value); //Would return the editor's content
+  console.log(editor.get('editor').value); //Would return the editor's content
 }</code></pre>
 
       <h6 id="api-open">open(<em>filename</em>)</h6>
       <p>Opens a file into the editor.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">openFileBtn.onclick = function(){
-  ee.open('some-file'); //Open a file when the user clicks this button
+  editor.open('some-file'); //Open a file when the user clicks this button
 }</code></pre>
 
       <h6 id="api-import">import(<em>filename</em>,[<em>content</em>])</h6>
       <p>Imports a string of markdown into a file. If the file already exists, it will be overwritten. Useful if you want to inject a bunch of content via AJAX.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">importFileBtn.onclick = function(){
-  ee.import('some-file',"#Imported markdown\nFancy, huh?"); //Imports a file when the user clicks this button
+  editor.import('some-file',"#Imported markdown\nFancy, huh?"); //Imports a file when the user clicks this button
 }</code></pre>
 
       <h6 id="api-rename">rename(<em>oldName</em>,<em>newName</em>)</h6>
@@ -159,59 +180,59 @@ var editor = new EpicEditor(element).load();</code></pre>
       <p class="example">Example:</p>
       <pre><code class="javascript">renameFileBtn.onclick = function(){
   var newName = prompt('What do you want to rename this file to?');
-  ee.rename('old-filename',newName); //Prompts a user and renames a file on button click
+  editor.rename('old-filename',newName); //Prompts a user and renames a file on button click
 }</code></pre>
 
       <h6 id="api-save">save()</h6>
       <p>Manually save a file. EpicEditor will save on keyup by default but if you are inserting content via ajax for example, this is useful.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">saveFileBtn.onclick = function(){
-  ee.save();
+  editor.save();
 }</code></pre>
 
       <h6 id="api-remove">remove(<em>name</em>)</h6>
       <p>Deletes a file.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">removeFileBtn.onclick = function(){
-  ee.remove('some-file');
+  editor.remove('some-file');
 }</code></pre>
 
       <h6 id="api-on">on(<em>event</em>,<em>handler</em>)</h6>
       <p>Sets up an event handler (callback) for a specified event. For all event types, see the <a href="#events">Events</a> section below.</p>
       <p class="example">Example:</p>
-      <pre><code class="javascript">ee.on('unload',function(){
+      <pre><code class="javascript">editor.on('unload',function(){
   console.log('Editor was removed');
 });</code></pre>
 
       <h6 id="api-emit">emit(<em>event</em>)</h6>
       <p>Sets off an event manually. Like jQuery's <code>.trigger()</code></p>
       <p class="example">Example:</p>
-      <pre><code class="javascript">ee.emit('unload'); //Would trigger the above handler</code></pre>
+      <pre><code class="javascript">editor.emit('unload'); //Would trigger the above handler</code></pre>
       
       <h6 id="api-removeListener">removeListener(<em>event</em>,[<em>handler</em>])</h6>
       <p>Allows you to remove all listeners for an event, or just the specified one.</p>
       <p class="example">Example:</p>
-      <pre><code class="javascript">ee.removeListener('unload'); //The handler above would no longer fire</code></pre>
+      <pre><code class="javascript">editor.removeListener('unload'); //The handler above would no longer fire</code></pre>
 
       <h6 id="api-preview">preview()</h6>
       <p>Will put the editor into preview mode.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">previewBtn.onclick = function(){
-  ee.preview();
+  editor.preview();
 }</code></pre>
       
       <h6 id="api-edit">edit()</h6>
       <p>Will put the editor into edit mode.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">editBtn.onclick = function(){
-  ee.edit();
+  editor.edit();
 }</code></pre>
       
       <h6 id="api-exportHTML">exportHTML()</h6>
       <p>Will return the generated HTML from the Markdown that you see in the preview mode. Useful to saving content to a database.</p>
       <p class="example">Example:</p>
       <pre><code class="javascript">syncWithServerBtn.onclick = function(){
-  var theHTML = ee.exportHTML();
+  var theHTML = editor.exportHTML();
   saveToServerAjaxCall('/save',{data:theHTML},function(){
     console.log('data was saved to a db');
   });
@@ -266,17 +287,14 @@ var editor = new EpicEditor(element).load();</code></pre>
         document.body.className += " " + 'offline-mode';
         console.log('Code highlighting will be disabled because yandex.st isn\'t loading or there is an error in the linked script.')
       }
+      var opts = {
+          file:{
+            defaultContent:"#EpicEditor\nThis is some default content. Go ahead, _change me_. "
+          }
+          , focusOnLoad:true
+          }
+        , editor = new EpicEditor(opts).load()
 
-      var examples = [document.getElementById('example-1')];
-
-      var ee1 = new EpicEditor(examples[0]);
-      ee1.options({
-        file:{
-          defaultContent:"#EpicEditor\nThis is some default content. Go ahead, _change me_. "
-        }
-        , focusOnLoad:true
-      })
-      .load();
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,9 @@
     <style>
       body {background:#FEED79;}
       #wrapper { width:600px;margin:0 auto;font-family:helvetica,arial,sans-serif;line-height:1.4em; }
-      #epiceditor { height:349px;border:1px solid #000; }
+      #example-1 { height:349px;border:1px solid #000; }
+      #epiceditor { margin: 20px 0; }
+      #tryit-unload-btn { display:none; }
       h1 { border-bottom:2px solid #000; padding:0 0 15px 0; font-size:38px; position:relative; }
       h3,h4,h5,h6 { margin-bottom:0; }
       h3 { font-size:20px; }
@@ -28,7 +30,7 @@
       <h2>An Embeddable JavaScript Markdown Editor</h2>
       <p>EpicEditor is an embeddable JavaScript <a href="http://daringfireball.net/projects/markdown/">Markdown</a> editor with some minor Markdown enhancements such as automatic link creation and code fencing.</p>
 
-      <div id="epiceditor"></div>
+      <div id="example-1"></div>
 
       <h3>Why</h3>
       <p>WYSIWYGs suck and they suck hard. Markdown is quickly becoming the replacement. <a href="http://github.com">GitHub</a>, <a href="http://stackoverflow.com">Stackoverflow</a>, and even blogging apps like <a href="http://posterous.com">Posterous</a> support Markdown now. This allows you to generate a Markdown editor with a preview, fullscreen editing, full CSS theming, and offline support with a simple:</p>
@@ -49,6 +51,9 @@
       <h5>Step 3: Init EpicEditor</h5>
       <pre><code class="javascript">var editor = new EpicEditor().load();</code></pre>
 
+      <a id="tryit-load-btn" onclick="toggleTryIt(true)">Try it!</a> <a id="tryit-unload-btn" onclick="toggleTryIt(false)">Unload it.</a>
+      <div id="epiceditor"></div>
+      
       <h4 id="api">API</h4>
       
       <p><strong>API Notes:</strong><br>
@@ -288,13 +293,31 @@ var editor = new EpicEditor(opts);</code></pre>
         console.log('Code highlighting will be disabled because yandex.st isn\'t loading or there is an error in the linked script.')
       }
       var opts = {
-          file:{
+          container: 'example-1'
+        , file:{
             defaultContent:"#EpicEditor\nThis is some default content. Go ahead, _change me_. "
           }
           , focusOnLoad:true
           }
         , editor = new EpicEditor(opts).load()
+      
+        , example = new EpicEditor();
+        
+      function toggleTryIt(s) {
+        var loader = document.getElementById('tryit-load-btn')
+          , unloader = document.getElementById('tryit-unload-btn')
 
+        if (s) {
+          example.load();
+          loader.style.display = 'none';
+          unloader.style.display = 'inline';
+        } else {
+          example.unload();
+          loader.style.display = 'inline';
+          unloader.style.display = 'none';
+        }
+
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
RE: [#44](https://github.com/OscarGodson/EpicEditor/pull/44#issuecomment-4384284)

I decided to name what was previously called `element`, `container` to try to be more clear on it's purpose. Hope that makes sense to you guys.

Also, I made an optional tweak to the `files` and `shortcuts` options. Singular seemed more consistent with an instance, similar to the `file` option. If you're not down with this feel free to disregard the last 2 commits in this pull request.
### A few additional notes/questions:
1. I'd love to be able to move away from updating `index.html` and `README` since they are nearly identical. Is this something we can throw in the `Jakefile` - to create the `index` on build?
2. Should file.name be checked to ensure it's a valid localStorage name - whatever that is?
3. Should the EE ID be protected (i.e. made not overwritable)?
### TODO:
- Bump version and disclaimer in docs however you see fit.
