### PR TITLE
Native fullscreen support in Firefox and Opera

### DIFF
--- a/epiceditor/js/epiceditor.js
+++ b/epiceditor/js/epiceditor.js
@@ -754,7 +754,7 @@
 
     // Sets up the NATIVE fullscreen editor/previewer for WebKit
     if (nativeFsWebkit) {
-      fsElement.addEventListener('webkitfullscreenchange', function () {
+      document.addEventListener('webkitfullscreenchange', function () {
         if (!document.webkitIsFullScreen && self._eeState.fullscreen) {
           self._exitFullscreen(fsElement);
         }

--- a/epiceditor/js/epiceditor.js
+++ b/epiceditor/js/epiceditor.js
@@ -707,7 +707,7 @@
         document.body.style.overflow = 'auto';
       }
       else {
-        (nativeFsWebkit && el.webkitCancelFullScreen()) ||
+        (nativeFsWebkit && document.webkitCancelFullScreen()) ||
         (nativeFsMoz && document.mozCancelFullScreen()) ||
         (nativeFsW3C && document.exitFullscreen());
       }


### PR DESCRIPTION
I had to resize the elements in the resize event listener even when using native fullscreen, because otherwise in opera (at least on linux) the editor would have the height of the document instead of spanning the whole screen (probably a bug in opera). This exposed another bug: _exitFullscreen calls the native cancel/exit function, which in turn calls _exitFullscreen again.
