### PR TITLE
Add .editorconfig to make it easy for developers to follow code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+; 2 spaces for indentation for all JavaScript files
+[*.js]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
If it were upto me, local `.vimrc` file would suffice, but `.editorconfig` is supported in more editors. I personally like tabs for indentation, and all my editors are configured to behave this way. Using `.editorconfig`, I won't have to worry about code style.

I think this is a easy win :smile: 
