### PR TITLE
Ticket #130 - docs are now minimally responsive

### DIFF
--- a/docs/css/main.css
+++ b/docs/css/main.css
@@ -205,3 +205,19 @@ p.btn-small {
 p.btn-small a {
   font-size:14px;
 }
+@media (max-width: 1050px){
+  #toc{
+   display: none;
+  }
+  #wrapper{
+    margin: 0 auto;
+    padding: 0;
+    max-width:100%;
+  }
+}
+
+@media (max-width: 1200px){
+  h1 span{
+    right: 150px;
+  }
+}


### PR DESCRIPTION
toc is hidden when it won't fit (very common pattern), and contents shrink-to-fit.

Far from "mobile first", as it were, but it's tolerable on a landscape phone. The CSS of the docs made me very sad inside (oh, oh the px...), but I'm not going to refactor the whole thing for my own satisfaction.

At worst, now you can keep the docs in a half-size window.
