### PR TITLE
Use _applyStyles instead of _applyAttrs when modifying the textarea

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -412,10 +412,8 @@
       var textareas = self.element.getElementsByTagName('textarea');
       if (textareas.length > 0) {
         self.settings.textarea = textareas[0];
-        _applyAttrs(self.settings.textarea, {
-          style: {
-            display: 'none'
-          }
+        _applyStyles(self.settings.textarea, {
+          display: 'none'
         });
       }
     }


### PR DESCRIPTION
Fixes a bug where the textarea style was set to "[object Object]" (a textual representation of the JSON) instead of the actual styles.
