### PR TITLE
This is document fix. Try-it unload button css style height fix.

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -58,6 +58,7 @@ $(function () {
       tryItBtn.innerHTML = 'Try it!';
       $('#epiceditor').removeClass('epiceditors')
       example.unload();
+      $('#epiceditor').height('auto');
     }
   }
 


### PR DESCRIPTION
When we unload after Try-it, the textarea disappears but the height
is not removed. So Text below textarea should come up after unloading.
