### PR TITLE
typo: it's -> its

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@ var editor = new EpicEditor(opts);</code></pre>
   </tr>
   <tr>
     <td><code>textarea</code></td>
-    <td>The ID (string) or element (object) of a textarea you would like to sync the editor&#39;s content with. On page load if there is content in the textarea, the editor will use that as it&#39;s content.</td>
+    <td>The ID (string) or element (object) of a textarea you would like to sync the editor&#39;s content with. On page load if there is content in the textarea, the editor will use that as its content.</td>
     <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
EpicEditor's great, thanks Oscar!
