### PR TITLE
Remove `text-align:left` from github.css

### DIFF
--- a/epiceditor/themes/preview/github.css
+++ b/epiceditor/themes/preview/github.css
@@ -225,7 +225,6 @@ body {
 #epiceditor-preview table tr th,
 #epiceditor-preview table tr td{
 	border:1px solid #ccc;
-	text-align:left;
 	margin:0;
 	padding:6px 13px;
 }


### PR DESCRIPTION
GFM has support for specifying alignment in tables by using colons in the header row (see https://help.github.com/articles/github-flavored-markdown#tables). Currently github.css overrides this by forcing left alignment for no good reason.
