### PR TITLE
Fix whitespace in editor

### DIFF
--- a/epiceditor/themes/editor/epic-dark.css
+++ b/epiceditor/themes/editor/epic-dark.css
@@ -10,4 +10,5 @@ body {
   line-height:1.35em;
   margin:0;
   padding:0;
+  white-space:pre-wrap;
 }

--- a/epiceditor/themes/editor/epic-light.css
+++ b/epiceditor/themes/editor/epic-light.css
@@ -9,4 +9,5 @@ body {
   line-height:1.35em;
   margin:0;
   padding:0;
+  white-space:pre-wrap;
 }


### PR DESCRIPTION
Currently, pasting external content with sequences of whitespace into
the editor results in the whitespaces being collapsed into a single one
(which is the default behaviour for HTML elements). Instead we really
want all the whitespaces to be preserved and displayed correctly.

Note that this only applies when pasting content, since pressing the
space bar on the keyboard will produce `&nbsp;` which are not collapsed
in any case.

See http://www.w3schools.com/cssref/pr_text_white-space.asp for
more details.
