### PR TITLE
Fix broken GitHub ribbon image src.

### DIFF
--- a/docs/footer.html
+++ b/docs/footer.html
@@ -1,7 +1,7 @@
   <div id="avatars">
     
   </div>
-  <a href="http://github.com/OscarGodson/EpicEditor"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/camo.github.com/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
+  <a href="http://github.com/OscarGodson/EpicEditor"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
 
   <script src="docs/js/jquery.min.js"></script>
   <script src="docs/js/prettify.js"></script>


### PR DESCRIPTION
It seems that `a248.e.akamai.net/camo.github.com` does not works now. So I fixed it to `camo.githubusercontent.com`. Copied new url from https://github.com/blog/273-github-ribbons. Changed only host, not path so theme of ribbon may be same with previous one.
