### PR TITLE
AMD compatible

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1891,5 +1891,10 @@
   // Used to store information to be shared across editors
   EpicEditor._data = {};
 
+  if (typeof define === 'function' && define.amd) {
+  define(function() { return EpicEditor; });
+} else {
   window.EpicEditor = EpicEditor;
+}
+
 })(window);


### PR DESCRIPTION
I use Require.js to load modules. A little change is required to make EpicEditor compatible with AMD.
