### PR TITLE
Add property file name to default schema

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -456,9 +456,10 @@
     // Setup local storage of files
     self._defaultFileSchema = function () {
       return {
-        content: self.settings.file.defaultContent
-      , created: new Date()
-      , modified: new Date()
+          fileName: self.settings.file.name
+        , content: self.settings.file.defaultContent
+        , created: new Date()
+        , modified: new Date()
       }
     }
 

--- a/test/test.exportFile.js
+++ b/test/test.exportFile.js
@@ -35,6 +35,7 @@ describe('.exportFile([fileName], [type])', function () {
     contents = editor.exportFile(null, 'json');
     expect((typeof contents)).to.be('string');
     obj = JSON.parse(contents);
+    expect(obj).to.have.property('fileName');
     expect(obj.content).to.match(/#foo\r?\n\r?\n##bar/);
     expect(obj).to.have.property('created');
     expect(obj).to.have.property('modified');

--- a/test/test.getFiles.js
+++ b/test/test.getFiles.js
@@ -47,6 +47,7 @@ describe('.getFiles([name])', function () {
   it('should return the right file when the name is specified', function () {
     var file = editor.getFiles(fooFile);
     expect(file).not.to.be(undefined);
+    expect(file).to.have.property('fileName');
     expect(file).to.have.property('modified');
     expect(file).to.have.property('created');
     expect(file.content).to.be('foo     bar');

--- a/test/test.save.js
+++ b/test/test.save.js
@@ -40,6 +40,7 @@ describe('.save()', function () {
   it('should fire the create event when saving a new file', function () {
     editor.on('create', function (file) {
       eventFired = true;
+      expect(file.fileName).to.be.ok();
       expect(file.content).to.be('foo');
       expect(file.created).to.be.ok();
       expect(file.modified).to.be.ok();


### PR DESCRIPTION
Add file name to default schema, useful for exporting purposes.
- Useful to export files and save on disk
