### PR TITLE
Tab indent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/tabIndent"]
+	path = libs/tabIndent
+	url = https://github.com/Jonybang/tabIndent.js

--- a/epiceditor/js/epiceditor.js
+++ b/epiceditor/js/epiceditor.js
@@ -655,7 +655,7 @@
     _insertCSSLink(self.settings.theme.editor, self.editorIframeDocument, 'theme');
 
     // Insert Editor Javascript
-    _insertJSScript('libs/tab-indent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
+    _insertJSScript('libs/tabIndent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
     _insertJSScript('src/init-tab-indent.js', self.editorIframeDocument, 'init-tab-indent');
     
     // Insert Previewer Stylesheet

--- a/epiceditor/js/epiceditor.js
+++ b/epiceditor/js/epiceditor.js
@@ -133,6 +133,27 @@
     headID.appendChild(cssNode);
   }
 
+  /**
+   * Inserts a <script> tag specifically for JS
+   * @param  {string} path The path to the JS file
+   * @param  {object} context In what context you want to apply this to (document, iframe, etc)
+   * @param  {string} id An id for you to reference later for changing properties of the <script>
+   * @returns {undefined}
+   */
+  function _insertJSScript(path, context, id) {
+    id = id || '';
+    var headID = context.getElementsByTagName("head")[0]
+      , jsNode = context.createElement('script');
+    
+    _applyAttrs(jsNode, {
+      type: 'text/javascript'
+    , id: id
+    , src: path
+    });
+
+    headID.appendChild(jsNode);
+  }
+
   // Simply replaces a class (o), to a new class (n) on an element provided (e)
   function _replaceClass(e, o, n) {
     e.className = e.className.replace(o, n);
@@ -632,6 +653,10 @@
     
     // Insert Editor Stylesheet
     _insertCSSLink(self.settings.theme.editor, self.editorIframeDocument, 'theme');
+
+    // Insert Editor Javascript
+    _insertJSScript('libs/tab-indent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
+    _insertJSScript('src/init-tab-indent.js', self.editorIframeDocument, 'init-tab-indent');
     
     // Insert Previewer Stylesheet
     _insertCSSLink(self.settings.theme.preview, self.previewerIframeDocument, 'theme');
@@ -648,6 +673,7 @@
     self.previewer = self.previewerIframeDocument.getElementById('epiceditor-preview');
    
     self.editor.contentEditable = true;
+		self.editor.setAttribute("id", "epiceditor-editor-body");
  
     // Firefox's <body> gets all fucked up so, to be sure, we need to hardcode it
     self.iframe.body.style.height = this.element.offsetHeight + 'px';

--- a/src/editor.js
+++ b/src/editor.js
@@ -655,7 +655,7 @@
     _insertCSSLink(self.settings.theme.editor, self.editorIframeDocument, 'theme');
 
     // Insert Editor Javascript
-    _insertJSScript('libs/tab-indent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
+    _insertJSScript('libs/tabIndent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
     _insertJSScript('src/init-tab-indent.js', self.editorIframeDocument, 'init-tab-indent');
     
     // Insert Previewer Stylesheet

--- a/src/editor.js
+++ b/src/editor.js
@@ -133,6 +133,27 @@
     headID.appendChild(cssNode);
   }
 
+  /**
+   * Inserts a <script> tag specifically for JS
+   * @param  {string} path The path to the JS file
+   * @param  {object} context In what context you want to apply this to (document, iframe, etc)
+   * @param  {string} id An id for you to reference later for changing properties of the <script>
+   * @returns {undefined}
+   */
+  function _insertJSScript(path, context, id) {
+    id = id || '';
+    var headID = context.getElementsByTagName("head")[0]
+      , jsNode = context.createElement('script');
+    
+    _applyAttrs(jsNode, {
+      type: 'text/javascript'
+    , id: id
+    , src: path
+    });
+
+    headID.appendChild(jsNode);
+  }
+
   // Simply replaces a class (o), to a new class (n) on an element provided (e)
   function _replaceClass(e, o, n) {
     e.className = e.className.replace(o, n);
@@ -632,6 +653,10 @@
     
     // Insert Editor Stylesheet
     _insertCSSLink(self.settings.theme.editor, self.editorIframeDocument, 'theme');
+
+    // Insert Editor Javascript
+    _insertJSScript('libs/tab-indent/js/tabIndent.js', self.editorIframeDocument, 'tab-indent');
+    _insertJSScript('src/init-tab-indent.js', self.editorIframeDocument, 'init-tab-indent');
     
     // Insert Previewer Stylesheet
     _insertCSSLink(self.settings.theme.preview, self.previewerIframeDocument, 'theme');
@@ -648,6 +673,7 @@
     self.previewer = self.previewerIframeDocument.getElementById('epiceditor-preview');
    
     self.editor.contentEditable = true;
+		self.editor.setAttribute("id", "epiceditor-editor-body");
  
     // Firefox's <body> gets all fucked up so, to be sure, we need to hardcode it
     self.iframe.body.style.height = this.element.offsetHeight + 'px';

--- a/src/init-tab-indent.js
+++ b/src/init-tab-indent.js
@@ -16,5 +16,7 @@ document.onreadystatechange = window.handleState;
 
 ready(function () {
 	var el = document.getElementById('epiceditor-editor-body');
+	tabIndent.config.focusDelay = 200;
+	tabIndent.config.tab = '\u00A0 \u00A0 \u00A0 ';
 	tabIndent.render(el);
 });

--- a/src/init-tab-indent.js
+++ b/src/init-tab-indent.js
@@ -1,0 +1,20 @@
+window.readyHandlers = [];
+window.ready = function ready(handler) {
+  window.readyHandlers.push(handler);
+  handleState();
+};
+
+window.handleState = function handleState () {
+  if (['interactive', 'complete'].indexOf(document.readyState) > -1) {
+    while(window.readyHandlers.length > 0) {
+      (window.readyHandlers.shift())();
+    }
+  }
+};
+
+document.onreadystatechange = window.handleState;
+
+ready(function () {
+	var el = document.getElementById('epiceditor-editor-body');
+	tabIndent.render(el);
+});


### PR DESCRIPTION
To check tab indent you should use the command
`git clone -b tab-indent --recursive https://github.com/Jonybang/EpicEditor.git`
for clone repo, because my variant of solution is using https://github.com/julianlam/tabIndent.js repo as an submodule(suggested by the @valx76).
I also had to significantly modify the code repository @julianlam https://github.com/julianlam/tabIndent.js for support editable container.
For this modification I created a fork 'adapted-for-epic-editor': https://github.com/Jonybang/tabIndent.js
