### PR TITLE
Added 'main' to point to build JS.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.0",
   "author": "Oscar Godson <oscargodson@gmail.com> (http://oscargodson.com)",
   "description": "An Embeddable Markdown Editor",
+  "main": "epiceditor/js/epiceditor.js",
   "devDependencies": {
     "uglify-js": "1.3.3",
     "jshint": "0.7.2",


### PR DESCRIPTION
## Resolves #387

When using NPM as the method to install EpicEditor, and then building the application (using WebPack for example), the main entry point JS file is not resolved.

Ie. These don't work.

```
var EpicEditor = require('epiceditor');
import EpicEditor from 'epiceditor';
```

The `package.json` is missing the `main` declaration that tells the builder which is the entrypoint file.
