### PR TITLE
fixes #378, broken twitter-avatars

### DIFF
--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -66,7 +66,7 @@ $(function () {
   prettyPrint()
 
   $(['OscarGodson', 'johnmdonahue', 'adam_bickford', 'sebnitu']).each(function (idx, val) {
-    var twimg = 'http://twitter.com/' + val + '/profile_image', twlink = 'http://twitter.com/' + val
+    var twimg = 'https://twitter.com/' + val + '/profile_image', twlink = 'https://twitter.com/' + val
       
     $('#avatars').append('<a href="' + twlink + '"><img class="avatar" src="' + twimg + '">')
   })

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -66,8 +66,7 @@ $(function () {
   prettyPrint()
 
   $(['OscarGodson', 'johnmdonahue', 'adam_bickford', 'sebnitu']).each(function (idx, val) {
-    var twimg = 'http://twitter.com/api/users/profile_image?screen_name=' + val
-      , twlink = 'http://twitter.com/' + val
+    var twimg = 'http://twitter.com/' + val + '/profile_image', twlink = 'http://twitter.com/' + val
       
     $('#avatars').append('<a href="' + twlink + '"><img class="avatar" src="' + twimg + '">')
   })


### PR DESCRIPTION
the old public-api doesn't exist anymore, new api needs auth.
Links in the form of twitter.com/[username]/profile_picture do work.
