### PR TITLE
docs: Fix simple typo, specificed -> specified

### DIFF
--- a/epiceditor/js/epiceditor.js
+++ b/epiceditor/js/epiceditor.js
@@ -1420,7 +1420,7 @@
   }
 
   /**
-   * Grabs a specificed HTML node. Use it as a shortcut to getting the iframe contents
+   * Grabs a specified HTML node. Use it as a shortcut to getting the iframe contents
    * @param   {String} name The name of the node (can be document, body, editor, previewer, or wrapper)
    * @returns {Object|Null}
    */

--- a/src/editor.js
+++ b/src/editor.js
@@ -1420,7 +1420,7 @@
   }
 
   /**
-   * Grabs a specificed HTML node. Use it as a shortcut to getting the iframe contents
+   * Grabs a specified HTML node. Use it as a shortcut to getting the iframe contents
    * @param   {String} name The name of the node (can be document, body, editor, previewer, or wrapper)
    * @returns {Object|Null}
    */


### PR DESCRIPTION
There is a small typo in epiceditor/js/epiceditor.js, src/editor.js.

Should read `specified` rather than `specificed`.

